### PR TITLE
podvm-root: add `After` to gen-issue.service

### DIFF
--- a/konflux/podvm-root/etc/systemd/system/gen-issue.service
+++ b/konflux/podvm-root/etc/systemd/system/gen-issue.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Generate issue to print to serial console at startup
+After=process-user-data.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
we need the pcr to be extended before we set the issue file or pcr will be printed empty