### PR TITLE
tekton: build-pipeline: use release registry for dm-verity task

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -121,7 +121,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:be82c55346e8810bd1edc5547f864064da6945979baccca7dfc99990b392a02b
           - name: kind
             value: task
       when:
@@ -164,7 +164,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:1f6e2c9beba52d21c562ba1dea55f579f67e33b80099615bfd2043864896284d
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:125aea525bcdb31ff86cb37d56e3d8369587ead48da3bc454d4344682724ca54
           - name: kind
             value: task
         resolver: bundles
@@ -217,7 +217,7 @@ spec:
           - name: name
             value: build-image-manifest
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-manifest:0.1@sha256:a279536c2e73b55e342e4827b4a0e9cf9abed8f27fb4363eea9de09a1da5b421
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-manifest:0.1@sha256:f7968e5806018b5526b42cfc8b2efe8dce8da79b56aa498cd10c1dd8759bf97d
           - name: kind
             value: task
         resolver: bundles
@@ -256,7 +256,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:a7766190229785bc5db9c62af92d46a83ea580a111b4b64a4e27f6caecae9489
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:bf7bdde00b7212f730c1356672290af6f38d070da2c8a316987b5c32fd49e0b9
           - name: kind
             value: task
         resolver: bundles

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -195,7 +195,7 @@ spec:
           - name: name
             value: build-dm-verity-image
           - name: bundle
-            value: quay.io/redhat-user-workloads/ose-osc-tenant/build-dm-verity-image-task@sha256:64fa0fbae40812f5e11dd528cdaf39138fb620edd5194e457205c5632b90714c
+            value: quay.io/redhat-user-workloads/ose-osc-tenant/build-dm-verity-image-task@sha256:213718b6ebb6796562a8e63dd246e1e8a4d3177eecfd55f8cbc58ee656ef756c
           - name: kind
             value: task
       when:

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -195,7 +195,7 @@ spec:
           - name: name
             value: build-dm-verity-image
           - name: bundle
-            value: quay.io/redhat-user-workloads/ose-osc-tenant/build-dm-verity-image-task@sha256:213718b6ebb6796562a8e63dd246e1e8a4d3177eecfd55f8cbc58ee656ef756c
+            value: quay.io/konflux-ci/ose-osc-tenant/build-dm-verity-image-task:0.1@sha256:213718b6ebb6796562a8e63dd246e1e8a4d3177eecfd55f8cbc58ee656ef756c
           - name: kind
             value: task
       when:


### PR DESCRIPTION
May be required for policy compliance or to get bot nudge updates.