### PR TITLE
osc-release-v1.10: update the tekton files with new IDs

### DIFF
--- a/.tekton/osc-dm-verity-image-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-pull-request.yaml
@@ -10,11 +10,11 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
       event == "pull_request" && target_branch
-      == "main"
+      == "osc-release-v1.10"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-dm-verity-image
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-dm-verity-image-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-dm-verity-image-on-pull-request
   namespace: ose-osc-tenant
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-10:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -33,7 +33,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-dm-verity-image
+    serviceAccountName: build-pipeline-osc-dm-verity-image-v1-10
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/osc-dm-verity-image-push.yaml
+++ b/.tekton/osc-dm-verity-image-push.yaml
@@ -8,11 +8,11 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "osc-release-v1.10"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-dm-verity-image
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-dm-verity-image-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-dm-verity-image-on-push
   namespace: ose-osc-tenant
@@ -23,13 +23,13 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-10:{{revision}}
   - name: dockerfile
     value: Dockerfile
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-dm-verity-image
+    serviceAccountName: build-pipeline-osc-dm-verity-image-v1-10
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
For the pipeline to trigger on the new branch, we need the tekton files to be updated so that they reference the new Konflux object names, branch name, and quay.io image location.