### PR TITLE
osc-release-1.10: update the podvm-payload reference

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -186,7 +186,7 @@ spec:
         - name: OUTPUT_IMAGE
           value: $(params.output-image)
         - name: PODVM_PAYLOAD_IMAGE
-          value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:d9b2ac90fd3663310a9160bcb232e1e7039869838d77c3509464b558d56f4142
+          value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-10@sha256:f615e0fc32a197c96c472eb3d7bdd113afacb141178b6117c95a8ee2b9188558
       runAfter:
         - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
We need to make sure we use the right component for the 1.10 release.