### PR TITLE
build-dm-verity-task: remove the PODVM_PAYLOAD_IMAGE parameter

### DIFF
--- a/konflux/Dockerfile
+++ b/konflux/Dockerfile
@@ -1,3 +1,5 @@
+FROM quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:c321535760ffc6f6b1529e31a3ccc56a890199076ceeb1ba24492b125ab01dcb as payload
+
 FROM registry.redhat.io/ubi9/ubi-init@sha256:4b29d34b9e310f1b8fa93bb2c727a1efa43328f5d647d50ebefb82cc1c4197ff
 
 RUN subscription-manager register --org "$(cat /activation-key/org)" --activationkey "$(cat /activation-key/activationkey)"
@@ -6,6 +8,9 @@ RUN dnf install -y \
 cpio systemd-ukify jq openssl qemu-img libguestfs guestfs-tools libguestfs-tools virt-install qemu-kvm edk2-ovmf nc
 
 COPY qemu.conf /etc/libvirt/qemu.conf
+
+COPY --from=payload /podvm-binaries.tar.gz /payload/
+COPY --from=payload /pause-bundle.tar.gz /payload/
 
 # to make virt-customize work
 ENV LIBGUESTFS_BACKEND=direct

--- a/task/build-dm-verity-image/0.1/build-dm-verity-image.yaml
+++ b/task/build-dm-verity-image/0.1/build-dm-verity-image.yaml
@@ -28,9 +28,6 @@ spec:
       description: Name of secret which contains the offline token for the Red Hat API
       name: REDHAT_OFFLINE_TOKEN_SECRET
       type: string
-    - name: PODVM_PAYLOAD_IMAGE
-      description: URL to the PodVM payload image.
-      type: string
   results:
     - description: Digest of the manifest list just built
       name: IMAGE_DIGEST
@@ -47,8 +44,6 @@ spec:
         value: $(params.ACTIVATION_KEY)
       - name: BUILDAH_IMAGE
         value: 'registry.access.redhat.com/ubi9/buildah:9.5-1739778322'
-      - name: PODVM_PAYLOAD_IMAGE
-        value: $(params.PODVM_PAYLOAD_IMAGE)
       - name: SBOM_TYPE
         value: spdx
     volumeMounts:
@@ -146,16 +141,11 @@ spec:
         export BUILD_DIR="$BUILD_DIR"
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
         export BUILDAH_IMAGE="$BUILDAH_IMAGE"
-        PODVM_PAYLOAD_IMAGE="$PODVM_PAYLOAD_IMAGE"
 
         REMOTESSHEOF
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-build.sh <<'REMOTESSHEOF'
-
-        podvm_payload_container=$(podman create $PODVM_PAYLOAD_IMAGE)
-        podman cp $podvm_payload_container:/podvm-binaries.tar.gz $BUILD_DIR
-        podman cp $podvm_payload_container:/pause-bundle.tar.gz $BUILD_DIR
 
         mkdir -p output/qcow2/
         echo "RUNNING BUILD"
@@ -244,8 +234,8 @@ spec:
         popd
 
         virt-customize \
-          --copy-in /workspace/podvm-binaries.tar.gz:/tmp/ \
-          --copy-in /workspace/pause-bundle.tar.gz:/tmp/ \
+          --copy-in /payload/podvm-binaries.tar.gz:/tmp/ \
+          --copy-in /payload/pause-bundle.tar.gz:/tmp/ \
           --copy-in ${root_tar_file}:/tmp/ \
           --run /workspace/scripts/script-podvm-maker.sh \
           -a $DISK


### PR DESCRIPTION
Having a parameter on the task is causing problems during our builds. Conforma (i.e: "Enterprise Contract") checks that the parameter is valid for the task. Now whenever the podvm-payload image is rebuilt, this check fails until we update the dm-verity image with the new reference.

This happens on the PR that modifies podvm-payload (which needs to be merged despite the failure), but it also happen after the PR is merged and podvm-payload is rebuilt, for EVERY pull request on all our repositories, until the dm-verity image is rebuilt - which can take some time.

This commit tries to work around that issue by putting the reference to the podvm-payload image in the "init" Dockerfile used by the task. The Dockerfile now takes the binaries from the podvm-payload image at build time, and we copy them to the VM directly from the container, without a need to give the task a reference.

The reference to podvm-payload in the Dockerfile will be updated as usual using nudges.