### PR TITLE
dm-verity pipeline: increase resource request

### DIFF
--- a/.tekton/osc-dm-verity-image-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-pull-request.yaml
@@ -30,6 +30,15 @@ spec:
       value: 5d
     - name: dockerfile
       value: Dockerfile
+  taskRunSpecs:
+    - pipelineTaskName: build-vm-image
+      stepSpecs:
+        - name: download-rhel-image
+          computeResources:
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-dm-verity-image-push.yaml
+++ b/.tekton/osc-dm-verity-image-push.yaml
@@ -26,6 +26,15 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  taskRunSpecs:
+    - pipelineTaskName: build-vm-image
+      stepSpecs:
+        - name: download-rhel-image
+          computeResources:
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
We are encountering repeated OOMKilled errors when running the build task, during the download of the RHEL image. This commit tries to fix it by increasing the memory request for this step of the build.