### PR TITLE
dm-verity: remove the PODVM_PAYLOAD_IMAGE parameter

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -185,8 +185,6 @@ spec:
           value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
         - name: OUTPUT_IMAGE
           value: $(params.output-image)
-        - name: PODVM_PAYLOAD_IMAGE
-          value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:211a4291cd13302a18ae2766a8e680a2593450ce31f119e78ac3367c5858104a
       runAfter:
         - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
The task has been modified to remove that parameter. We can now remove it from the build pipeline itself.

The podvm-payload reference is now written in the konflux/Dockerfile instead.