### PR TITLE
build-dm-verity-task: make the labels a parameter to the task

### DIFF
--- a/.tekton/build-dm-verity-image-debug.yaml
+++ b/.tekton/build-dm-verity-image-debug.yaml
@@ -32,6 +32,9 @@ spec:
       description: Name of secret which contains the offline token for the Red Hat API
       name: REDHAT_OFFLINE_TOKEN_SECRET
       type: string
+    - name: LABELS
+      type: string
+      description: A comma-separated list of key=value pairs to add as labels to the built image
   results:
     - description: Digest of the manifest list just built
       name: IMAGE_DIGEST
@@ -52,6 +55,8 @@ spec:
         value: 'registry.access.redhat.com/ubi9/buildah:9.5-1739778322'
       - name: SBOM_TYPE
         value: spdx
+      - name: LABELS
+        value: $(params.LABELS)
     volumeMounts:
       - mountPath: "/var/workdir"
         name: workdir
@@ -395,6 +400,7 @@ spec:
         set -ex
 
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
+        export LABELS="$LABELS"
 
         REMOTESSHEOF
 
@@ -420,18 +426,13 @@ spec:
         buildah_container=$(buildah from scratch)
         buildah add $buildah_container "$DISK_PATH" image/podvm.qcow2
         buildah add $buildah_container "$MEASUREMENTS_PATH" image/measurements.json
-        buildah config --label com.redhat.component='osc-dm-verity-image' $buildah_container
-        buildah config --label description='Debug PodVM with DM-Verity support' $buildah_container
-        buildah config --label distribution-scope=private $buildah_container
-        buildah config --label io.k8s.description='PodVM image for confidential computing with device mapper verity support' $buildah_container
-        buildah config --label name='openshift-sandboxed-containers/osc-dm-verity-image' $buildah_container
-        buildah config --label cpe='cpe:/a:redhat:confidential_compute_attestation:1.12::el9' $buildah_container
-        buildah config --label release='1' $buildah_container
-        buildah config --label url='https://github.com/confidential-devhub/coco-podvm-scripts' $buildah_container
-        buildah config --label vcs-ref='main' $buildah_container
-        buildah config --label vcs-type='git' $buildah_container
-        buildah config --label vendor='Red Hat' $buildah_container
-        buildah config --label version='1.12' $buildah_container
+        # Get the list of labels from the LABELS env variable and apply them to the image
+        IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+        for label in "${LABEL_ARRAY[@]}"; do
+          # Remove leading and trailing whitespace from the label
+          label=$(echo "$label" | xargs)
+          buildah config --label "$label" $buildah_container
+        done
         buildah commit $buildah_container $image_name
         buildah push --digestfile image-digest --authfile /.docker/config.json --retry 10 --all $image_name $OUTPUT_IMAGE
 

--- a/.tekton/build-pipeline-debug.yaml
+++ b/.tekton/build-pipeline-debug.yaml
@@ -38,6 +38,10 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - name: LABELS
+    type: string
+    description: A comma-separated list of key=value pairs to add as labels to the built image
+    default: ""
   results:
   - description: ""
     name: CHAINS-GIT_URL
@@ -107,6 +111,8 @@ spec:
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: OUTPUT_IMAGE
       value: $(params.output-image)
+    - name: LABELS
+      value: $(params.LABELS)
     runAfter:
     - clone-repository
     taskRef:

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -74,6 +74,10 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - name: LABELS
+    type: string
+    description: A comma-separated list of key=value pairs to add as labels to the built image
+    default: ""
   - name: enable-package-registry-proxy
     default: 'true'
     description: Use the package registry proxy when prefetching dependencies
@@ -179,6 +183,8 @@ spec:
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: OUTPUT_IMAGE
       value: $(params.output-image)
+    - name: LABELS
+      value: $(params.LABELS)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/osc-dm-verity-image-debug-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-debug-pull-request.yaml
@@ -28,6 +28,20 @@ spec:
       value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-debug:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    - name: LABELS
+      value: >
+        com.redhat.component=osc-dm-verity-image,
+        description=Debug PodVM with DM-Verity support,
+        distribution-scope=private,
+        io.k8s.description=PodVM image for confidential computing with device mapper verity support,
+        name=openshift-sandboxed-containers/osc-dm-verity-image,
+        cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+        release=1,
+        url=https://github.com/confidential-devhub/coco-podvm-scripts,
+        vcs-ref=main,
+        vcs-type=git,
+        vendor=Red Hat,
+        version=1.12
   taskRunSpecs:
     - pipelineTaskName: build-vm-image
       stepSpecs:

--- a/.tekton/osc-dm-verity-image-debug-push.yaml
+++ b/.tekton/osc-dm-verity-image-debug-push.yaml
@@ -24,6 +24,20 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-debug:{{revision}}
+  - name: LABELS
+    value: >
+      com.redhat.component=osc-dm-verity-image,
+      description=Debug PodVM with DM-Verity support,
+      distribution-scope=private,
+      io.k8s.description=PodVM image for confidential computing with device mapper verity support,
+      name=openshift-sandboxed-containers/osc-dm-verity-image,
+      cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+      release=1,
+      url=https://github.com/confidential-devhub/coco-podvm-scripts,
+      vcs-ref=main,
+      vcs-type=git,
+      vendor=Red Hat,
+      version=1.12
   taskRunSpecs:
     - pipelineTaskName: build-vm-image
       stepSpecs:

--- a/.tekton/osc-dm-verity-image-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-pull-request.yaml
@@ -30,6 +30,20 @@ spec:
       value: 5d
     - name: dockerfile
       value: Dockerfile
+    - name: LABELS
+      value: >
+        com.redhat.component=osc-dm-verity-image,
+        description=PodVM with DM-Verity support,
+        distribution-scope=private,
+        io.k8s.description=PodVM image for confidential computing with device mapper verity support,
+        name=openshift-sandboxed-containers/osc-dm-verity-image,
+        cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+        release=1,
+        url=https://github.com/confidential-devhub/coco-podvm-scripts,
+        vcs-ref=main,
+        vcs-type=git,
+        vendor=Red Hat,
+        version=1.12
   taskRunSpecs:
     - pipelineTaskName: build-vm-image
       stepSpecs:

--- a/.tekton/osc-dm-verity-image-push.yaml
+++ b/.tekton/osc-dm-verity-image-push.yaml
@@ -26,6 +26,20 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: LABELS
+    value: >
+      com.redhat.component=osc-dm-verity-image,
+      description=PodVM with DM-Verity support,
+      distribution-scope=private,
+      io.k8s.description=PodVM image for confidential computing with device mapper verity support,
+      name=openshift-sandboxed-containers/osc-dm-verity-image,
+      cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+      release=1,
+      url=https://github.com/confidential-devhub/coco-podvm-scripts,
+      vcs-ref=main,
+      vcs-type=git,
+      vendor=Red Hat,
+      version=1.12
   taskRunSpecs:
     - pipelineTaskName: build-vm-image
       stepSpecs:

--- a/task/build-dm-verity-image/0.1/build-dm-verity-image.yaml
+++ b/task/build-dm-verity-image/0.1/build-dm-verity-image.yaml
@@ -32,6 +32,9 @@ spec:
       description: Name of secret which contains the offline token for the Red Hat API
       name: REDHAT_OFFLINE_TOKEN_SECRET
       type: string
+    - name: LABELS
+      type: string
+      description: A comma-separated list of key=value pairs to add as labels to the built image
   results:
     - description: Digest of the manifest list just built
       name: IMAGE_DIGEST
@@ -52,6 +55,8 @@ spec:
         value: 'registry.access.redhat.com/ubi9/buildah:9.5-1739778322'
       - name: SBOM_TYPE
         value: spdx
+      - name: LABELS
+        value: $(params.LABELS)
     volumeMounts:
       - mountPath: "/var/workdir"
         name: workdir
@@ -219,7 +224,6 @@ spec:
         dnf install -y kernel-{uki-virt,modules,modules-extra}-${KERNEL_VERSION}
         # Update shim fallback CSV to ensure Azure VM boots latest UKI (needed only when kernel is updated)
         printf "shimx64.efi,redhat,\\\\\\EFI\\\\\\Linux\\\\\\\"\$(cat /etc/machine-id)"-"\$(rpm -q --queryformat %{VERSION}-%{RELEASE}\\\\\\n kernel-uki-virt | tail -1)".x86_64.efi ,UKI bootentry\n" | iconv -f ASCII -t UCS-2 > /boot/efi/EFI/redhat/BOOTX64.CSV
-
 
         REMOTESSHEOF
 
@@ -396,6 +400,7 @@ spec:
         set -ex
 
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
+        export LABELS="$LABELS"
 
         REMOTESSHEOF
 
@@ -421,18 +426,13 @@ spec:
         buildah_container=$(buildah from scratch)
         buildah add $buildah_container "$DISK_PATH" image/podvm.qcow2
         buildah add $buildah_container "$MEASUREMENTS_PATH" image/measurements.json
-        buildah config --label com.redhat.component='osc-dm-verity-image' $buildah_container
-        buildah config --label description='PodVM with DM-Verity support' $buildah_container
-        buildah config --label distribution-scope=private $buildah_container
-        buildah config --label io.k8s.description='PodVM image for confidential computing with device mapper verity support' $buildah_container
-        buildah config --label name='openshift-sandboxed-containers/osc-dm-verity-image' $buildah_container
-        buildah config --label cpe='cpe:/a:redhat:confidential_compute_attestation:1.12::el9' $buildah_container
-        buildah config --label release='1' $buildah_container
-        buildah config --label url='https://github.com/confidential-devhub/coco-podvm-scripts' $buildah_container
-        buildah config --label vcs-ref='main' $buildah_container
-        buildah config --label vcs-type='git' $buildah_container
-        buildah config --label vendor='Red Hat' $buildah_container
-        buildah config --label version='1.12' $buildah_container
+        # Get the list of labels from the LABELS env variable and apply them to the image
+        IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+        for label in "${LABEL_ARRAY[@]}"; do
+          # Remove leading and trailing whitespace from the label
+          label=$(echo "$label" | xargs)
+          buildah config --label "$label" $buildah_container
+        done
         buildah commit $buildah_container $image_name
         buildah push --digestfile image-digest --authfile /.docker/config.json --retry 10 --all $image_name $OUTPUT_IMAGE
 


### PR DESCRIPTION
The task currently has hardcoded labels that it applies to the image. Part of them contain the release version in it, forcing us to modify/rebuild the task every time we make a new release. It also means that a given task cannot be used for different releases.

This commit moves the list of labels to a parameter to the task, and modify the build script to loop on that list and apply them one by one. It also modifies the dm-verity build pipelines to provide this list as intended.

Similar changes are applied to the debug flavor of the build task and pipelines, for consistency.