### PR TITLE
dm-verity: update the podvm-payload image reference to use the v1.12 branch build

### DIFF
--- a/.tekton/osc-dm-verity-image-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-pull-request.yaml
@@ -16,7 +16,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
     appstudio.openshift.io/component: osc-dm-verity-image-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-dm-verity-image-on-pull-request-v1-12
+  name: osc-dm-verity-image-v1-12-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:

--- a/.tekton/osc-dm-verity-image-push.yaml
+++ b/.tekton/osc-dm-verity-image-push.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
     appstudio.openshift.io/component: osc-dm-verity-image-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-dm-verity-image-on-push-v1-12
+  name: osc-dm-verity-image-v1-12-on-push
   namespace: ose-osc-tenant
 spec:
   params:

--- a/konflux/Dockerfile
+++ b/konflux/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:911df63d29774d519271597888e30f093a42a6c4a56ac62e939199ecdbec47d2 as payload
+FROM quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-12@sha256:0a3a3c29e6a3bd3fdfed9402479711a3fd179dbee9d995a058dc812948b98790 as payload
 
 FROM registry.redhat.io/ubi9/ubi-init@sha256:2a40900a2ac68e14888509b66782f2d321427153fdd9e056fa187e1138f5b548
 


### PR DESCRIPTION
This makes sure we use the right build AND should re-enable the nudge PR when building podvm-payload from that branch.

Also fixes the pipeline name for consistency - I didn't see a build issue because of it, but I prefer to have the pipelines named consistently everywhere.

Fixes: KATA-5167