### PR TITLE
release: update CPE label version to 1.130

### DIFF
--- a/.tekton/osc-dm-verity-image-debug-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-debug-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
         distribution-scope=private,
         io.k8s.description=PodVM image for confidential computing with device mapper verity support,
         name=openshift-sandboxed-containers/osc-dm-verity-image,
-        cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+        cpe=cpe:/a:redhat:confidential_compute_attestation:1.130::el9,
         release=1,
         url=https://github.com/confidential-devhub/coco-podvm-scripts,
         vcs-ref=main,

--- a/.tekton/osc-dm-verity-image-debug-push.yaml
+++ b/.tekton/osc-dm-verity-image-debug-push.yaml
@@ -31,7 +31,7 @@ spec:
       distribution-scope=private,
       io.k8s.description=PodVM image for confidential computing with device mapper verity support,
       name=openshift-sandboxed-containers/osc-dm-verity-image,
-      cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+      cpe=cpe:/a:redhat:confidential_compute_attestation:1.130::el9,
       release=1,
       url=https://github.com/confidential-devhub/coco-podvm-scripts,
       vcs-ref=main,

--- a/.tekton/osc-dm-verity-image-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
         distribution-scope=private,
         io.k8s.description=PodVM image for confidential computing with device mapper verity support,
         name=openshift-sandboxed-containers/osc-dm-verity-image,
-        cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+        cpe=cpe:/a:redhat:confidential_compute_attestation:1.130::el9,
         release=1,
         url=https://github.com/confidential-devhub/coco-podvm-scripts,
         vcs-ref=main,

--- a/.tekton/osc-dm-verity-image-push.yaml
+++ b/.tekton/osc-dm-verity-image-push.yaml
@@ -33,7 +33,7 @@ spec:
       distribution-scope=private,
       io.k8s.description=PodVM image for confidential computing with device mapper verity support,
       name=openshift-sandboxed-containers/osc-dm-verity-image,
-      cpe=cpe:/a:redhat:confidential_compute_attestation:1.12::el9,
+      cpe=cpe:/a:redhat:confidential_compute_attestation:1.130::el9,
       release=1,
       url=https://github.com/confidential-devhub/coco-podvm-scripts,
       vcs-ref=main,


### PR DESCRIPTION
ProdSec product-definitions registers the OSC 1.13 stream with CPE version 1.130. Update all tekton pipeline files to match.