### PR TITLE
konflux: add a tag to our images that mentions the PR it built from

### DIFF
--- a/.tekton/build-pipeline-debug.yaml
+++ b/.tekton/build-pipeline-debug.yaml
@@ -42,6 +42,10 @@ spec:
     type: string
     description: A comma-separated list of key=value pairs to add as labels to the built image
     default: ""
+  - name: additional-tags
+    type: array
+    default: []
+    description: Additional tags to apply to the built image (e.g. pr-<number> for PR builds)
   results:
   - description: ""
     name: CHAINS-GIT_URL
@@ -136,6 +140,26 @@ spec:
         value: build-image-index
       - name: bundle
         value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:0b4251ea0fab38be2b1441bea2788220d4cf2963ffb854a0ed90992fbabbe122
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: apply-tags
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
+      value:
+      - $(params.additional-tags[*])
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: apply-tags
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/osc-dm-verity-image-debug-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-debug-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
         vcs-type=git,
         vendor=Red Hat,
         version=1.12
+    - name: additional-tags
+      value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
   taskRunSpecs:
     - pipelineTaskName: build-vm-image
       stepSpecs:

--- a/.tekton/osc-dm-verity-image-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-pull-request.yaml
@@ -44,6 +44,10 @@ spec:
         vcs-type=git,
         vendor=Red Hat,
         version=1.12
+    - name: additional-tags
+      value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
   taskRunSpecs:
     - pipelineTaskName: build-vm-image
       stepSpecs:


### PR DESCRIPTION
Identifying images on quay is hard. This commit makes sure we tag our image with the PR number it was built from. This should make it easier to identify what image we can use for testing a build before we merge the PR.

We create 2 tags, for different purposes:
- pr-[PR number]: this is overriden on each build, and tags the latest build
- pullreq-[PR number]-[head commit SHA]: provides an easy to find tag, while keeping an history of builds.