### PR TITLE
konflux: update the tekton files for building 1.13 from new branch

### DIFF
--- a/.tekton/build-dm-verity-image-task-pull-request.yaml
+++ b/.tekton/build-dm-verity-image-task-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "task/build-dm-verity-image/0.1/***".pathChanged() || ".tekton/build-dm-verity-image-task-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "osc-release-v1.13" && ( "task/build-dm-verity-image/0.1/***".pathChanged() || ".tekton/build-dm-verity-image-task-pull-request.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: build-definitions
-    appstudio.openshift.io/component: build-dm-verity-image-task
+    appstudio.openshift.io/application: build-definitions-v1-13
+    appstudio.openshift.io/component: build-dm-verity-image-task-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: build-dm-verity-image-task-on-pull-request
+  name: build-dm-verity-image-task-v1-13-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/build-dm-verity-image-task:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/build-dm-verity-image-task-v1-13:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -309,7 +309,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-build-dm-verity-image-task
+    serviceAccountName: build-pipeline-build-dm-verity-image-task-v1-13
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/build-dm-verity-image-task-push.yaml
+++ b/.tekton/build-dm-verity-image-task-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "task/build-dm-verity-image/0.1/***".pathChanged() || ".tekton/build-dm-verity-image-task-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "osc-release-v1.13" && ( "task/build-dm-verity-image/0.1/***".pathChanged() || ".tekton/build-dm-verity-image-task-pull-request.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: build-definitions
-    appstudio.openshift.io/component: build-dm-verity-image-task
+    appstudio.openshift.io/application: build-definitions-v1-13
+    appstudio.openshift.io/component: build-dm-verity-image-task-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: build-dm-verity-image-task-on-push
+  name: build-dm-verity-image-task-v1-13-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/build-dm-verity-image-task:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/build-dm-verity-image-task-v1-13:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -299,7 +299,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-build-dm-verity-image-task
+    serviceAccountName: build-pipeline-build-dm-verity-image-task-v1-13
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-dm-verity-image-debug-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-debug-pull-request.yaml
@@ -10,13 +10,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
       event == "pull_request" && target_branch
-      == "main"
+      == "osc-release-v1.13"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: osc-dm-verity-image-debug
-    appstudio.openshift.io/component: osc-dm-verity-image-debug
+    appstudio.openshift.io/application: osc-dm-verity-image-debug-v1-13
+    appstudio.openshift.io/component: osc-dm-verity-image-debug-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: osc-dm-verity-image-debug-on-pull-request
+  name: osc-dm-verity-image-debug-v1-13-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-debug:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-debug-v1-13:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: LABELS
@@ -58,7 +58,7 @@ spec:
   pipelineRef:
     name: build-pipeline-debug
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-dm-verity-image-debug
+    serviceAccountName: build-pipeline-osc-dm-verity-image-debug-v1-13
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/osc-dm-verity-image-debug-push.yaml
+++ b/.tekton/osc-dm-verity-image-debug-push.yaml
@@ -8,13 +8,13 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "osc-release-v1.13"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: osc-dm-verity-image-debug
-    appstudio.openshift.io/component: osc-dm-verity-image-debug
+    appstudio.openshift.io/application: osc-dm-verity-image-debug-v1-13
+    appstudio.openshift.io/component: osc-dm-verity-image-debug-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: osc-dm-verity-image-debug-on-push
+  name: osc-dm-verity-image-debug-v1-13-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-debug:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-debug-v1-13:{{revision}}
   - name: LABELS
     value: >
       com.redhat.component=osc-dm-verity-image,
@@ -50,7 +50,7 @@ spec:
   pipelineRef:
     name: build-pipeline-debug
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-dm-verity-image-debug
+    serviceAccountName: build-pipeline-osc-dm-verity-image-debug-v1-13
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-dm-verity-image-pull-request.yaml
+++ b/.tekton/osc-dm-verity-image-pull-request.yaml
@@ -10,13 +10,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
       event == "pull_request" && target_branch
-      == "main"
+      == "osc-release-v1.13"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-dm-verity-image
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-13
+    appstudio.openshift.io/component: osc-dm-verity-image-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: osc-dm-verity-image-on-pull-request
+  name: osc-dm-verity-image-v1-13-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-13:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
     - name: dockerfile
@@ -60,7 +60,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-dm-verity-image
+    serviceAccountName: build-pipeline-osc-dm-verity-image-v1-13
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/osc-dm-verity-image-push.yaml
+++ b/.tekton/osc-dm-verity-image-push.yaml
@@ -8,13 +8,13 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "osc-release-v1.13"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-dm-verity-image
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-13
+    appstudio.openshift.io/component: osc-dm-verity-image-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: osc-dm-verity-image-on-push
+  name: osc-dm-verity-image-v1-13-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-dm-verity-image-v1-13:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: LABELS
@@ -52,7 +52,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-dm-verity-image
+    serviceAccountName: build-pipeline-osc-dm-verity-image-v1-13
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
For the pipeline to trigger on the new branch, we need the tekton files to be updated so that they reference the new Konflux object names, branch name, and quay.io image location.

Fixes: KATA-5601