### PR TITLE
[1.13] osc-dm-verity-image: update the prefetch-dependencies image reference

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -162,7 +162,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
As asked by the Conforma check: the image we use is obsolete and need to be updated


(cherry picked from commit 918af1de50ef0954f3f84783acc524f76dea9877)